### PR TITLE
Update python_version for 3.13

### DIFF
--- a/archer.json
+++ b/archer.json
@@ -25,7 +25,7 @@
     "product_version_regex": ".*",
     "min_phantom_version": "6.2.1",
     "fips_compliant": true,
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "logo": "logo_rsa.svg",
     "logo_dark": "logo_rsa_dark.svg",
     "configuration": {

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * chore(ci): Pre-commit config updates
 * update dependencies in requirements [PSAAS-22812]
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)