### PR TITLE
fix: improve RSA Archer connector validation and data handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.0
     hooks:
       - id: build-docs
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.0
+    rev: v2.2.3
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: RSA Archer
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.
 Third Party Software Attributions:
 
 @@@@============================================================================
@@ -40,4 +40,3 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/archer.json
+++ b/archer.json
@@ -57,7 +57,7 @@
             "description": "Verify server certificate",
             "data_type": "boolean",
             "order": 4,
-            "default": false
+            "default": true
         },
         "cef_mapping": {
             "description": "CEF to Archer mapping",

--- a/archer.json
+++ b/archer.json
@@ -13,7 +13,7 @@
     ],
     "package_name": "phantom_archer",
     "type": "ticketing",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "main_module": "archer_connector.py",
     "app_version": "3.2.3",
     "latest_tested_versions": [

--- a/archer_connector.py
+++ b/archer_connector.py
@@ -173,11 +173,17 @@ class ArcherConnector(BaseConnector):
 
         completed_records = 0
         max_ingested_id = max_content_id
+        restarted_from_first_page = False
         self.proxy.excluded_fields = [x.lower().strip() for x in config.get("exclude_fields", "").split(",")]
         while completed_records < max_records:
             records = self.proxy.find_records(application, tracking_id_field, None, self.POLLING_PAGE_SIZE, sort=sort_type, page=last_page)
             nrecs = len(records)
             if not records:
+                if last_page > 1 and not restarted_from_first_page:
+                    self.send_progress(f"Archer page {last_page} is empty; restarting ingestion scan from page 1")
+                    last_page = 1
+                    restarted_from_first_page = True
+                    continue
                 break
             self.send_progress(f"Processing {nrecs} records, page {last_page}...")
             for i, rec in enumerate(records):

--- a/archer_connector.py
+++ b/archer_connector.py
@@ -767,6 +767,10 @@ class ArcherConnector(BaseConnector):
         name_value = param.get("name_value")
         groups = param.get("groups")
         content_id = param.get("content_id")
+        if content_id:
+            status, content_id = self._validate_integer(action_result, content_id, "content_id", False)
+            if phantom.is_fail(status):
+                return action_result.get_status()
         lid = self.proxy.get_levelId_for_app(application)
         if lid is None:
             return action_result.set_status(phantom.APP_ERROR, f"Error: Could not identify application {application}")
@@ -870,6 +874,10 @@ class ArcherConnector(BaseConnector):
         field_id = param.get("field_id")
         name_value = param.get("name_value")
         content_id = param.get("content_id")
+        if content_id:
+            status, content_id = self._validate_integer(action_result, content_id, "content_id", False)
+            if phantom.is_fail(status):
+                return action_result.get_status()
         lid = self.proxy.get_levelId_for_app(application)
 
         if lid is None:

--- a/archer_connector.py
+++ b/archer_connector.py
@@ -186,6 +186,7 @@ class ArcherConnector(BaseConnector):
                     continue
                 break
             self.send_progress(f"Processing {nrecs} records, page {last_page}...")
+            page_fully_scanned = True
             for i, rec in enumerate(records):
                 content_id = int(rec["@contentId"])
                 if content_id <= max_content_id:
@@ -243,12 +244,14 @@ class ArcherConnector(BaseConnector):
                 max_ingested_id = max(max_ingested_id, c["data"]["archer_content_id"])
                 completed_records += 1
                 if completed_records >= max_records:
+                    if i < nrecs - 1:
+                        page_fully_scanned = False
+                        self.send_progress(f"Reached ingestion limit with records still pending on Archer page {last_page}")
                     break
 
-            if nrecs < self.POLLING_PAGE_SIZE:
+            if not page_fully_scanned or nrecs < self.POLLING_PAGE_SIZE:
                 break
-            else:
-                last_page += 1
+            last_page += 1
 
         self.save_progress(f"Ingested {completed_records} records")
         if not self.is_poll_now():

--- a/archer_connector.py
+++ b/archer_connector.py
@@ -276,7 +276,7 @@ class ArcherConnector(BaseConnector):
         """Returns an archer_utils.ArcherAPISession object."""
         if not self.proxy:
             ep, user, pwd, instance, users_domain = self._get_proxy_args()
-            verify = self.get_config().get("verify_ssl", False)
+            verify = self.get_config().get("verify_ssl", True)
             self.debug_print(f"New Archer API session at ep:{ep}, user:{user}, verify:{verify}")
             self.proxy = archer_utils.ArcherAPISession(ep, user, pwd, instance, users_domain, verify, self)
             archer_utils.W = self.debug_print

--- a/archer_connector.py
+++ b/archer_connector.py
@@ -1,6 +1,6 @@
 # File: archer_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -190,12 +190,7 @@ class ArcherConnector(BaseConnector):
                 cef = {}
                 for field in rec.get("Field", []):
                     name = field.get("@name")
-                    ftype = field.get("@type")
-                    content = None
-                    if ftype in []:
-                        pass
-                    else:
-                        content = field.get("#text")
+                    content = field.get("#text")
                     if name.lower() in cef_mapping:
                         cef[cef_mapping.get(name.lower(), name)] = content
                     if name == tracking_id_field:

--- a/archer_consts.py
+++ b/archer_consts.py
@@ -1,6 +1,6 @@
 # File: archer_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/archer_consts.py
+++ b/archer_consts.py
@@ -56,7 +56,7 @@ ERR_MSG_UNAVAILABLE = "Error message unavailable. Please check the asset configu
 ARCHER_OPERATOR_VALUELIST = ["and", "or"]
 ARCHER_EQUALITY_VALUELIST = ["contains", "equals"]
 
-ARCHER_XPATH_GROUP = "/soap:Envelope/soap:Body/dummy:LookupGroupResponse/dummy:LookupGroupResult/dummy:Groups/dummy:/Group/dummy:Name"
+ARCHER_XPATH_GROUP = "/soap:Envelope/soap:Body/dummy:LookupGroupResponse/dummy:LookupGroupResult/dummy:Groups/dummy:Group/dummy:Name"
 ARCHER_INVALID_JSON = "Invalid JSON string. Must be a dictionary containing key-value pairs"
 
 DEFAULT_TIMEOUT = 30

--- a/archer_consts.py
+++ b/archer_consts.py
@@ -56,7 +56,7 @@ ERR_MSG_UNAVAILABLE = "Error message unavailable. Please check the asset configu
 ARCHER_OPERATOR_VALUELIST = ["and", "or"]
 ARCHER_EQUALITY_VALUELIST = ["contains", "equals"]
 
-ARCHER_XPATH_GROUP = "/soap:Envelope/soap:Body/dummy:LookupGroupResponse/dummy:LookupGroupResult/dummy:Groups/dummy:Group/dummy:Name"
+ARCHER_XPATH_GROUP = "/soap:Envelope/soap:Body/dummy:LookupGroupResponse/dummy:LookupGroupResult/dummy:Groups/dummy:/Group/dummy:Name"
 ARCHER_INVALID_JSON = "Invalid JSON string. Must be a dictionary containing key-value pairs"
 
 DEFAULT_TIMEOUT = 30

--- a/archer_soap.py
+++ b/archer_soap.py
@@ -41,6 +41,26 @@ ALL_NS_MAP = NS_MAP.copy()
 ALL_NS_MAP["dummy"] = ARCHERNS
 
 DEBUG = False
+MAX_XML_RESPONSE_BYTES = 10 * 1024 * 1024
+
+
+def parse_untrusted_xml(xml_data):
+    if isinstance(xml_data, str):
+        xml_data = xml_data.encode("utf-8")
+    if len(xml_data) > MAX_XML_RESPONSE_BYTES:
+        raise ValueError("Archer XML response exceeds the 10 MiB safety limit")
+    if b"<!DOCTYPE" in xml_data.upper():
+        raise ValueError("Archer XML responses must not contain a DTD")
+    parser = etree.XMLParser(
+        resolve_entities=False,
+        no_network=True,
+        load_dtd=False,
+        huge_tree=False,
+    )
+    document = etree.parse(BytesIO(xml_data), parser=parser)
+    if document.docinfo.doctype:
+        raise ValueError("Archer XML responses must not contain a DTD")
+    return document
 
 
 class ArcherSOAP:
@@ -231,9 +251,7 @@ class ArcherSOAP:
         if not result:
             return []
 
-        r_io = BytesIO(result[0].text.encode("UTF8"))
-        xmlp = etree.XMLParser(encoding="utf-8")
-        search_result = etree.parse(r_io, parser=xmlp)
+        search_result = parse_untrusted_xml(result[0].text)
         return search_result.xpath("/Records/Record")
 
     def get_record(self, content_id, module_id):
@@ -433,7 +451,5 @@ class ArcherSOAP:
                 session_token = api[0].getchildren()[0]
                 session_token.text = self.conn_obj.sessionToken
                 return self._do_request(uri, doc, method="post")
-            r_io = BytesIO(response.text.encode("UTF8"))
-            resp_doc = etree.parse(r_io)
-            return resp_doc
+            return parse_untrusted_xml(response.text)
         raise ValueError("Invalid Method")

--- a/archer_soap.py
+++ b/archer_soap.py
@@ -221,7 +221,7 @@ class ArcherSOAP:
             else:
                 fc = etree.SubElement(co, "TextFilterCondition")
                 op = etree.SubElement(fc, "Operator")
-                op.text = "Contains"
+                op.text = comparison
             fi = etree.SubElement(fc, "Field")
             fi.text = str(key_id)
             v = etree.SubElement(fc, "Value")

--- a/archer_soap.py
+++ b/archer_soap.py
@@ -1,6 +1,6 @@
 # File: archer_soap.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/archer_soap.py
+++ b/archer_soap.py
@@ -328,7 +328,7 @@ class ArcherSOAP:
         type_formatter_map = {}
         for i in (1, 2, 3, 19):
             type_formatter_map[i] = self.plain_field
-        for i in (4, 9, 18, 27, 23):
+        for i in (4, 6, 9, 18, 27, 23):
             type_formatter_map[i] = self.mv_field
         for i in (8,):
             type_formatter_map[i] = self.user_field
@@ -351,8 +351,9 @@ class ArcherSOAP:
         update_doc = etree.ElementTree(r)
         for field in fields:
             fn = type_formatter_map.get(field["type"])
-            if fn:
-                fn(field, r)
+            if not fn:
+                raise ValueError(f"Unsupported Archer field type {field['type']} for field {field['id']}")
+            fn(field, r)
 
         fv.text = etree.tostring(update_doc, pretty_print=True)
 
@@ -382,8 +383,9 @@ class ArcherSOAP:
         update_doc = etree.ElementTree(r)
         for field in fields:
             fn = type_formatter_map.get(field["type"])
-            if fn:
-                fn(field, r)
+            if not fn:
+                raise ValueError(f"Unsupported Archer field type {field['type']} for field {field['id']}")
+            fn(field, r)
 
         fv.text = etree.tostring(update_doc, pretty_print=True)
 

--- a/archer_soap.py
+++ b/archer_soap.py
@@ -12,7 +12,6 @@
 # the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
-import xml.etree.ElementTree as et
 from io import BytesIO
 
 import requests
@@ -127,21 +126,20 @@ class ArcherSOAP:
         u.text = groupname
         resp_doc = self._do_request(self.base_uri + "/accesscontrol.asmx", doc)
         resp_root = resp_doc.getroot()
-        try:
-            result = resp_root.xpath(archer_consts.ARCHER_XPATH_GROUP, namespaces=ALL_NS_MAP)
-            if result:
-                for name_ele in result:
-                    if name_ele.text == groupname:
-                        for node in name_ele.itersiblings(tag="Id"):
-                            return int(node.text)
+        result = resp_root.xpath(archer_consts.ARCHER_XPATH_GROUP, namespaces=ALL_NS_MAP)
+        for name_element in result:
+            if name_element.text == groupname:
+                for node in name_element.itersiblings(tag="Id"):
+                    return int(node.text)
 
-        except (etree.XPathEvalError, AttributeError):
-            grp_id = None
-            result = resp_root.xpath(archer_consts.ARCHER_XPATH_GROUP_OTHER, namespaces=ALL_NS_MAP)
-            if result and isinstance(result, list):
-                result = et.fromstring(result[0].text)
-                grp_id = result.find(".//Id").text
-                return grp_id
+        result = resp_root.xpath(archer_consts.ARCHER_XPATH_GROUP_OTHER, namespaces=ALL_NS_MAP)
+        if result and result[0].text:
+            inner_document = parse_untrusted_xml(result[0].text)
+            for group in inner_document.xpath("//*[local-name()='Group']"):
+                names = group.xpath("./*[local-name()='Name']")
+                identifiers = group.xpath("./*[local-name()='Id']")
+                if names and identifiers and names[0].text == groupname:
+                    return int(identifiers[0].text)
 
         return
 

--- a/archer_utils.py
+++ b/archer_utils.py
@@ -161,7 +161,7 @@ class ArcherAPISession:
         if r.status_code == consts.ARCHER_UNAUTHORIZED_USER:
             self.get_token()
             return self._rest_call(ep, meth, data)
-        r.raise_for_status
+        r.raise_for_status()
         try:
             r = r.content.decode() or r.reason
         except (UnicodeDecodeError, AttributeError):

--- a/archer_utils.py
+++ b/archer_utils.py
@@ -19,6 +19,7 @@ we use them both as necessary.
 
 import functools
 import json
+import re
 import sys
 
 import requests
@@ -276,13 +277,6 @@ class ArcherAPISession:
             return None
         return j["RequestedObject"]["Id"]
 
-    def concatenate_list_data(self, fv_list):
-        """Concatenates list values and create string"""
-        result = ""
-        for element in fv_list:
-            result += str(element)
-        return result
-
     @memoize
     def get_field_details(self, fieldId):
         """Returns details about the field with the given ID."""
@@ -302,14 +296,14 @@ class ArcherAPISession:
 
         if not field_value:
             raise TypeError("Either content id or Tracking ID field and record name are required")
-        fv = filter(lambda x: x.isdigit(), field_value)
-        fv = self.concatenate_list_data(list(fv))
-        if not fv:
-            return None
-        fv = int(fv)
+        match = re.fullmatch(r"\D*([0-9]+)\D*", str(field_value).strip())
+        if not match:
+            raise ValueError("Tracking ID values must contain exactly one contiguous numeric identifier")
+        fv = int(match.group(1))
 
         records = self.asoap.find_records(modid, app, fid, field_name, fv, filter_type="numeric")
-        # should only get one
+        if len(records) > 1:
+            raise ValueError(f'Multiple records matched tracking ID "{field_value}"')
         if records:
             return records[0].get("contentId")
         return None

--- a/archer_utils.py
+++ b/archer_utils.py
@@ -173,6 +173,9 @@ class ArcherAPISession:
         """Returns ID of the field with the given name in the given record.
         Return None if not found.
         """
+        cid = int(cid)
+        if cid <= 0:
+            raise ValueError("Content ID must be a positive integer")
         W(f"Getting fieldId for {fname} in record {cid}")
         j = json.loads(self._rest_call(f"/api/core/content/{cid}"))
         if not ("RequestedObject" in j and "FieldContents" in j["RequestedObject"]):

--- a/archer_utils.py
+++ b/archer_utils.py
@@ -1,6 +1,6 @@
 # File: archer_utils.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/archer_views.py
+++ b/archer_views.py
@@ -1,6 +1,6 @@
 # File: archer_views.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/get_report.html
+++ b/get_report.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!--File: get_report.html
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/get_report.html
+++ b/get_report.html
@@ -115,7 +115,7 @@ and limitations under the License.
                     <td>
                       {% if value.contains %}
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': {{ value.contains }}, 'value':'{{ value.value }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': {{ value.contains }}, 'value':'{{ value.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ value.value }}
                           &nbsp;
                           <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/get_ticket.html
+++ b/get_ticket.html
@@ -107,7 +107,7 @@ and limitations under the License.
             </td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains':['archer application'], 'value':'{{ result.parameters.application }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains':['archer application'], 'value':'{{ result.parameters.application|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.parameters.application }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>
@@ -120,7 +120,7 @@ and limitations under the License.
               </td>
               <td>
                 <a href="javascript:;"
-                   onclick="context_menu(this, [{'contains':['archer user friendly id'], 'value':'{{ result.parameters.name_value }}' }], 0, {{ container.id }}, null, false);">
+                   onclick="context_menu(this, [{'contains':['archer user friendly id'], 'value':'{{ result.parameters.name_value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                   {{ result.parameters.name_value }}
                   &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                 </a>
@@ -133,7 +133,7 @@ and limitations under the License.
             </td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains':['archer content id'], 'value':'{{ result.content_id }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains':['archer content id'], 'value':'{{ result.content_id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.content_id }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>

--- a/get_ticket.html
+++ b/get_ticket.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!--File: get_ticket.html
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/list_tickets.html
+++ b/list_tickets.html
@@ -118,7 +118,7 @@ and limitations under the License.
                     <td>
                       {% if value.contains %}
                         <a href="javascript:;"
-                           onclick="context_menu(this, [{'contains': {{ value.contains }}, 'value':'{{ value.value }}' }], 0, {{ container.id }}, null, false);">
+                           onclick="context_menu(this, [{'contains': {{ value.contains }}, 'value':'{{ value.value|escapejs }}' }], 0, {{ container.id }}, null, false);">
                           {{ value.value }}
                           &nbsp;
                           <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/list_tickets.html
+++ b/list_tickets.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!--File: list_tickets.html
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/phantom_utils.py
+++ b/phantom_utils.py
@@ -1,6 +1,6 @@
 # File: phantom_utils.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Escaped dynamic Archer widget values before embedding them in inline JavaScript handlers.
 * Enabled TLS certificate verification by default for RSA Archer connections.
+* Rejected DTDs and bounded RSA Archer XML responses before parsing them with external entities disabled.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -8,3 +8,4 @@
 * Restarted scheduled ingestion from page one when a persisted Archer page no longer exists.
 * Serialized Type 6 values-list fields and rejected unsupported field types instead of silently dropping writes.
 * Reported Archer REST HTTP errors instead of treating their response bodies as successful results.
+* Preserved the current Archer page checkpoint when scheduled ingestion reaches its record cap mid-page.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Enabled TLS certificate verification by default for RSA Archer connections.
 * Rejected DTDs and bounded RSA Archer XML responses before parsing them with external entities disabled.
 * Hardened embedded Archer group lookup XML and corrected its primary XPath expression.
+* Required positive numeric content IDs before constructing Archer record API paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Escaped dynamic Archer widget values before embedding them in inline JavaScript handlers.
+* Enabled TLS certificate verification by default for RSA Archer connections.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -7,3 +7,4 @@
 * Required positive numeric content IDs before constructing Archer record API paths.
 * Restarted scheduled ingestion from page one when a persisted Archer page no longer exists.
 * Serialized Type 6 values-list fields and rejected unsupported field types instead of silently dropping writes.
+* Reported Archer REST HTTP errors instead of treating their response bodies as successful results.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Escaped dynamic Archer widget values before embedding them in inline JavaScript handlers.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,4 @@
 * Rejected DTDs and bounded RSA Archer XML responses before parsing them with external entities disabled.
 * Hardened embedded Archer group lookup XML and corrected its primary XPath expression.
 * Required positive numeric content IDs before constructing Archer record API paths.
+* Restarted scheduled ingestion from page one when a persisted Archer page no longer exists.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -6,3 +6,4 @@
 * Hardened embedded Archer group lookup XML and corrected its primary XPath expression.
 * Required positive numeric content IDs before constructing Archer record API paths.
 * Restarted scheduled ingestion from page one when a persisted Archer page no longer exists.
+* Serialized Type 6 values-list fields and rejected unsupported field types instead of silently dropping writes.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,7 +3,7 @@
 * Escaped dynamic Archer widget values before embedding them in inline JavaScript handlers.
 * Enabled TLS certificate verification by default for RSA Archer connections.
 * Rejected DTDs and bounded RSA Archer XML responses before parsing them with external entities disabled.
-* Hardened embedded Archer group lookup XML and corrected its primary XPath expression.
+* Hardened embedded Archer group lookup XML before parsing it.
 * Required positive numeric content IDs before constructing Archer record API paths.
 * Restarted scheduled ingestion from page one when a persisted Archer page no longer exists.
 * Serialized Type 6 values-list fields and rejected unsupported field types instead of silently dropping writes.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -9,3 +9,4 @@
 * Serialized Type 6 values-list fields and rejected unsupported field types instead of silently dropping writes.
 * Reported Archer REST HTTP errors instead of treating their response bodies as successful results.
 * Preserved the current Archer page checkpoint when scheduled ingestion reaches its record cap mid-page.
+* Rejected ambiguous tracking ID values and multiple record matches instead of silently targeting the first result.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -10,3 +10,4 @@
 * Reported Archer REST HTTP errors instead of treating their response bodies as successful results.
 * Preserved the current Archer page checkpoint when scheduled ingestion reaches its record cap mid-page.
 * Rejected ambiguous tracking ID values and multiple record matches instead of silently targeting the first result.
+* Honored exact-match operators for Archer text searches instead of forcing substring matching.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Escaped dynamic Archer widget values before embedding them in inline JavaScript handlers.
 * Enabled TLS certificate verification by default for RSA Archer connections.
 * Rejected DTDs and bounded RSA Archer XML responses before parsing them with external entities disabled.
+* Hardened embedded Archer group lookup XML and corrected its primary XPath expression.


### PR DESCRIPTION
### Bug Fixes

- Escape dynamic widget values before embedding them in inline JavaScript.
- Enable TLS certificate verification by default.
- Bound and harden outer, embedded-search, and group-lookup XML parsing.
- Validate content IDs before constructing REST paths.
- Recover ingestion after upstream page removal and preserve partial-page checkpoints.
- Serialize Type 6 fields, reject unsupported write fields, and surface REST HTTP errors.
- Resolve tracking IDs strictly and honor exact text-search operators.

The proposed group-lookup XPath correction was removed during review because no authoritative Archer response schema established the replacement structure. The hardened embedded-XML fallback remains and addresses the reported unsafe parse without making that unsupported assumption.

Tracking: [PAPP-38051](https://splunk.atlassian.net/browse/PAPP-38051), [PSAAS-30741](https://splunk.atlassian.net/browse/PSAAS-30741), [PSAAS-30744](https://splunk.atlassian.net/browse/PSAAS-30744), [PSAAS-31417](https://splunk.atlassian.net/browse/PSAAS-31417), [PSAAS-31803](https://splunk.atlassian.net/browse/PSAAS-31803), [PSAAS-31941](https://splunk.atlassian.net/browse/PSAAS-31941), [PSAAS-32000](https://splunk.atlassian.net/browse/PSAAS-32000), [PSAAS-32033](https://splunk.atlassian.net/browse/PSAAS-32033), [PSAAS-32129](https://splunk.atlassian.net/browse/PSAAS-32129), and [PSAAS-32152](https://splunk.atlassian.net/browse/PSAAS-32152).

### Manual Documentation

- [x] I have verified that no manual documentation change is required; generated connector documentation reflects the secure TLS default and existing action contracts remain intact.

### Testing

- `python3 -m py_compile __init__.py archer_connector.py archer_consts.py archer_soap.py archer_utils.py archer_views.py phantom_utils.py`
- `pre-commit run --all-files` — passed
- Hosted `pre-commit` and `compile` — passed

No connector-local unit-test scaffolding was added because this is a legacy BaseConnector app.

Written by Codex with AI assistance.

## Release impact

This PR contains a breaking configuration change and must ship as a major release. Archer now verifies server certificates by default; existing assets must trust the server certificate chain or explicitly disable verification. The corresponding functional commit includes a parseable `BREAKING CHANGE:` trailer for semantic-release.

Merge strategy: merge commit only; do not squash

Release-impact note added by Codex.